### PR TITLE
Change dependency injection config according to the fragment lifecycle.

### DIFF
--- a/presentation/src/main/java/com/zxjdev/smile/presentation/application/base/BaseActivity.java
+++ b/presentation/src/main/java/com/zxjdev/smile/presentation/application/base/BaseActivity.java
@@ -26,7 +26,7 @@ public abstract class BaseActivity extends AppCompatActivity {
         initializeInjector();
     }
 
-    /*@Override
+    @Override
     protected void onStart() {
         super.onStart();
         if (mLogLifeCycle) Timber.d("onStart");
@@ -48,7 +48,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     protected void onStop() {
         super.onStop();
         if (mLogLifeCycle) Timber.d("onStop");
-    }*/
+    }
 
     @Override
     protected void onDestroy() {

--- a/presentation/src/main/java/com/zxjdev/smile/presentation/application/base/BaseFragment.java
+++ b/presentation/src/main/java/com/zxjdev/smile/presentation/application/base/BaseFragment.java
@@ -18,6 +18,8 @@ public abstract class BaseFragment extends Fragment {
     protected boolean mLogLifeCycle = true;
     protected String mClassName = BaseFragment.this.getClass().getSimpleName();
 
+    protected boolean mInitializedInjector = false;
+
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -28,7 +30,6 @@ public abstract class BaseFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (mLogLifeCycle) Timber.d("%s onCreate", mClassName);
-        initializeInjector();
     }
 
     @Nullable
@@ -37,6 +38,7 @@ public abstract class BaseFragment extends Fragment {
         ViewGroup container,
         Bundle savedInstanceState) {
         if (mLogLifeCycle) Timber.d("%s onCreateView", mClassName);
+
         return super.onCreateView(inflater, container, savedInstanceState);
     }
 
@@ -44,6 +46,11 @@ public abstract class BaseFragment extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (mLogLifeCycle) Timber.d("%s onActivityCreated", mClassName);
+
+        if (!mInitializedInjector) {
+            initializeComponent();
+            mInitializedInjector = true;
+        }
     }
 
     @Override
@@ -80,6 +87,9 @@ public abstract class BaseFragment extends Fragment {
     public void onDestroy() {
         super.onDestroy();
         if (mLogLifeCycle) Timber.d("%s onDestroy", mClassName);
+
+        releaseComponent();
+        mInitializedInjector = true;
     }
 
     @Override
@@ -103,7 +113,9 @@ public abstract class BaseFragment extends Fragment {
     /**
      * 配置依赖注入
      */
-    protected abstract void initializeInjector();
+    protected abstract void initializeComponent();
+
+    protected abstract void releaseComponent();
 
     protected ApplicationComponent getApplicationComponent() {
         return ((SmileApplication) getActivity().getApplication()).getApplicationComponent();

--- a/presentation/src/main/java/com/zxjdev/smile/presentation/moment/list/MomentsFragment.java
+++ b/presentation/src/main/java/com/zxjdev/smile/presentation/moment/list/MomentsFragment.java
@@ -44,12 +44,17 @@ public class MomentsFragment extends BaseFragment {
     }
 
     @Override
-    protected void initializeInjector() {
+    protected void initializeComponent() {
         if (getActivity() instanceof MainActivity) {
             mMomentsFragmentComponent = ((MainActivity) getActivity()).getComponent()
                 .plus(new MomentsFragmentModule());
             mMomentsFragmentComponent.inject(this);
         }
+    }
+
+    @Override
+    protected void releaseComponent() {
+        mMomentsFragmentComponent = null;
     }
 
     @Nullable
@@ -64,10 +69,18 @@ public class MomentsFragment extends BaseFragment {
         return view;
     }
 
-    private void initUi() {
-        mRvMoments.setAdapter(mAdapter);
-        mRvMoments.setLayoutManager(new LinearLayoutManager(getActivity()));
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        initData();
+    }
 
+    private void initUi() {
+        mRvMoments.setLayoutManager(new LinearLayoutManager(getActivity()));
+    }
+
+    private void initData() {
+        mRvMoments.setAdapter(mAdapter);
         mAdapter.setMoments(moments);
     }
 

--- a/presentation/src/main/java/com/zxjdev/smile/presentation/user/settings/SettingsFragment.java
+++ b/presentation/src/main/java/com/zxjdev/smile/presentation/user/settings/SettingsFragment.java
@@ -35,13 +35,16 @@ public class SettingsFragment extends BaseFragment implements ISettingsView {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        mSettingsPresenter.setView(this);
     }
 
     @Override
-    protected void initializeInjector() {
+    protected void initializeComponent() {
         getApplicationComponent().plus(new ActivityModule(getActivity())).inject(this);
+    }
+
+    @Override
+    protected void releaseComponent() {
+
     }
 
     @Nullable
@@ -52,6 +55,12 @@ public class SettingsFragment extends BaseFragment implements ISettingsView {
         View view = inflater.inflate(R.layout.fragment_settings, container, false);
         ButterKnife.bind(this, view);
         return view;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        mSettingsPresenter.setView(this);
     }
 
     @Override


### PR DESCRIPTION
Adjust the dagger component lifecycle according to fragment’s lifecycle.
Consider situations when fragment attach to activity from backstack or
recreate when rotate the screen.